### PR TITLE
Hide Wi-SUN editor cards when WSBRD is unavailable

### DIFF
--- a/src/dashboard/Dashboard.jsx
+++ b/src/dashboard/Dashboard.jsx
@@ -16,13 +16,17 @@
  */
 
 import { FlexItem, Grid, GridItem } from "@patternfly/react-core";
+import { useContext } from "react";
 import WSBRDActiveConf from "./WSBRDActiveConf/WSBRDActiveConf";
 import WSBRDConfEditor from "./WSBRDConfEditor/WSBRDConfEditor";
 import WSBRDGakKeys from "./WSBRDGakKeys/WSBRDGakKeys";
 import WSBRDGtkKeys from "./WSBRDGtkKeys/WSBRDGtkKeys";
 import WSBRDStatus from "./WSBRDStatus";
+import { AppContext } from "../app";
 
 const Dashboard = () => {
+    const { wsbrdInstalled } = useContext(AppContext);
+
     return (
         <Grid hasGutter>
             <GridItem lg={6}>
@@ -36,9 +40,11 @@ const Dashboard = () => {
                     <GridItem>
                         <WSBRDStatus />
                     </GridItem>
-                    <GridItem>
-                        <WSBRDConfEditor />
-                    </GridItem>
+                    {wsbrdInstalled && (
+                        <GridItem>
+                            <WSBRDConfEditor />
+                        </GridItem>
+                    )}
                 </Grid>
             </GridItem>
             <GridItem lg={6}>
@@ -46,12 +52,16 @@ const Dashboard = () => {
                     <FlexItem>
                         <WSBRDActiveConf />
                     </FlexItem>
-                    <FlexItem>
-                        <WSBRDGakKeys />
-                    </FlexItem>
-                    <FlexItem>
-                        <WSBRDGtkKeys />
-                    </FlexItem>
+                    {wsbrdInstalled && (
+                        <FlexItem>
+                            <WSBRDGakKeys />
+                        </FlexItem>
+                    )}
+                    {wsbrdInstalled && (
+                        <FlexItem>
+                            <WSBRDGtkKeys />
+                        </FlexItem>
+                    )}
                 </Grid>
             </GridItem>
         </Grid>

--- a/src/dashboard/WSBRDConfEditor/WSBRDConfEditorContent.jsx
+++ b/src/dashboard/WSBRDConfEditor/WSBRDConfEditorContent.jsx
@@ -15,11 +15,12 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Alert, TextArea } from "@patternfly/react-core";
 import cockpit from 'cockpit';
 import CenteredContent from "../../utils/CenteredContent";
 import Loading from "../../utils/Loading";
+import { AppContext } from "../../app";
 
 const _ = cockpit.gettext;
 
@@ -30,6 +31,7 @@ const WSBRDConfEditorContent = () => {
     const [cockpitTag, setCockpitTag] = useState(undefined);
     const [hasError, setHasError] = useState(false);
     const [error, setError] = useState(null);
+    const { socAgentActive } = useContext(AppContext);
 
     useEffect(() => {
         file.read().then((data, tag) => {
@@ -77,12 +79,22 @@ const WSBRDConfEditorContent = () => {
     }
 
     return (
-        <TextArea
-            style={{ height: '100%' }}
-            aria-label="wsbrd-conf"
-            value={content}
-            onChange={onContentChange}
-        />
+        <>
+            {socAgentActive && (
+                <Alert
+                    variant='info'
+                    isInline
+                    title="Wi-SUN SoC Border Router Agent service is active. Editing is disabled."
+                />
+            )}
+            <TextArea
+                style={{ height: '100%' }}
+                aria-label="wsbrd-conf"
+                value={content}
+                onChange={onContentChange}
+                isDisabled={socAgentActive}
+            />
+        </>
     );
 };
 

--- a/src/dashboard/WSBRDGakKeys/WSBRDGakKeysContent.jsx
+++ b/src/dashboard/WSBRDGakKeys/WSBRDGakKeysContent.jsx
@@ -36,9 +36,17 @@ const WSBRDGakKeysContent = () => {
     const [loading, setLoading] = useState(true);
     const [hasError, setHasError] = useState(false);
 
-    const { active } = useContext(AppContext);
+    const { active, socAgentActive } = useContext(AppContext);
 
     useEffect(() => {
+        if (socAgentActive) {
+            if (loading) {
+                setLoading(false);
+            }
+            setHasError(false);
+            return;
+        }
+
         // only make a dbus request if the service is active
         if (active !== true) {
             if (loading) {
@@ -70,11 +78,22 @@ const WSBRDGakKeysContent = () => {
         };
 
         getProperties();
-    }, [active, loading]);
+    }, [active, loading, socAgentActive]);
 
     if (loading) {
         return (
             <Loading />
+        );
+    }
+
+    if (socAgentActive) {
+        return (
+            <CenteredContent>
+                <Alert
+                    variant='info'
+                    title="Wi-SUN SoC Border Router Agent service is active. GAK Keys are unavailable."
+                />
+            </CenteredContent>
         );
     }
 

--- a/src/dashboard/WSBRDGtkKeys/WSBRDGtkKeysContent.jsx
+++ b/src/dashboard/WSBRDGtkKeys/WSBRDGtkKeysContent.jsx
@@ -36,9 +36,17 @@ const WSBRDGtkKeysContent = () => {
     const [loading, setLoading] = useState(true);
     const [hasError, setHasError] = useState(false);
 
-    const { active } = useContext(AppContext);
+    const { active, socAgentActive } = useContext(AppContext);
 
     useEffect(() => {
+        if (socAgentActive) {
+            if (loading) {
+                setLoading(false);
+            }
+            setHasError(false);
+            return;
+        }
+
         // only make a dbus request if the service is active
         if (active !== true) {
             if (loading) {
@@ -70,11 +78,22 @@ const WSBRDGtkKeysContent = () => {
         };
 
         getProperties();
-    }, [active, loading]);
+    }, [active, loading, socAgentActive]);
 
     if (loading) {
         return (
             <Loading />
+        );
+    }
+
+    if (socAgentActive) {
+        return (
+            <CenteredContent>
+                <Alert
+                    variant='info'
+                    title="Wi-SUN SoC Border Router Agent service is active. GTK Keys are unavailable."
+                />
+            </CenteredContent>
         );
     }
 


### PR DESCRIPTION
## Summary
- query systemd for wisun-borderrouter.service installation state and the Wi-SUN SoC agent activity
- hide the configuration editor and GTK/GAK key cards when the border router service is not installed
- disable editing of wsbrd.conf and key retrieval while the SoC agent service is active

