### PR TITLE
WI_SUN-5476: init bc_interval_ms in default_host_settings

### DIFF
--- a/wisun-br-bridge-agent/src/ws_br_agent_soc_host.c
+++ b/wisun-br-bridge-agent/src/ws_br_agent_soc_host.c
@@ -55,6 +55,7 @@ static const ws_br_agent_settings_t default_host_settings = {
   .network_size = WS_BR_AGENT_NETWORK_SIZE_SMALL,
   .tx_power_ddbm = 200,
   .uc_dwell_interval_ms = 255U,
+  .bc_interval_ms = 1000U,
   .bc_dwell_interval_ms = 255U,
   .max_neighbor_count = 32U,
   .allowed_channels = "0-255",


### PR DESCRIPTION
Depending if a settings file was loaded or not,
this could lead to the agent asking the BR to set its bc_interval_ms to 0, which is invalid and led to an assert